### PR TITLE
Add in is_empty and has_length checks for HashSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,13 @@ Note: Descriptions and examples for each of the assertions are further down in t
 #### contains_entry
 #### does_not_contain_entry
 
+### HashSets
+#### has_length
+#### is_empty
+#### contains (from iterator)
+#### does_not_contain (from iterator)
+#### contains_all_of (from iterator)
+
 ### IntoIterator/Iterator
 #### contains
 #### does_not_contain
@@ -777,6 +784,44 @@ assert_that(&test_map).does_not_contain_entry(&"hello", &"hey");
      but was: present in hashmap
 ```
 
+### HashSets
+#### has_length
+
+Asserts that the length of the subject hashset is equal to the provided length. The subject type must be of `HashSet`.
+
+##### Example
+```rust
+let mut test_map = HashSet::new();
+test_map.insert(1);
+test_map.insert(2);
+
+assert_that(&test_map).has_length(2);
+```
+
+##### Failure Message
+```bash
+	expected: hashset to have length <1>
+	 but was: <2>
+```
+
+#### is_empty
+
+Asserts that the subject hashset is empty. The subject type must be of `HashSet`.
+
+##### Example
+```rust
+let test_map: HashSet<u8> = HashSet::new();
+assert_that(&test_map).is_empty();
+```
+
+##### Failure Message
+```bash
+	expected: an empty hashset
+	 but was: a hashset with length <1>
+```
+
+#### Iterator based asserts
+Since a hashset is implements Iterator, all the Iterator assertions below also apply (e.g. contains & does_not_contain)
 
 ### IntoIterator/Iterator
 #### contains

--- a/src/hashset.rs
+++ b/src/hashset.rs
@@ -1,0 +1,157 @@
+use super::{AssertionFailure, Spec};
+
+use std::collections::HashSet;
+use std::fmt::Debug;
+use std::hash::Hash;
+
+pub trait HashSetAssertions<'s> {
+    fn has_length(&mut self, expected: usize);
+    fn is_empty(&mut self);
+}
+
+impl<'s, K> HashSetAssertions<'s> for Spec<'s, HashSet<K>>
+where
+    K: Hash + Eq + Debug,
+{
+    /// Asserts that the length of the subject HashSet is equal to the provided length. The subject
+    /// type must be of `HashSet`.
+    ///
+    /// ```rust
+    /// # use speculoos::prelude::*;
+    /// # use std::collections::HashSet;
+    /// let mut test_map = HashSet::new();
+    /// test_map.insert(1);
+    /// test_map.insert(2);
+    ///
+    /// assert_that(&test_map).has_length(2);
+    /// ```
+    fn has_length(&mut self, expected: usize) {
+        let subject = self.subject;
+
+        if subject.len() != expected {
+            AssertionFailure::from_spec(self)
+                .with_expected(format!("HashSet to have length <{}>", expected))
+                .with_actual(format!("<{}>", subject.len()))
+                .fail();
+        }
+    }
+
+    /// Asserts that the subject HashSet is empty. The subject type must be of `HashSet`.
+    ///
+    /// ```rust
+    /// # use speculoos::prelude::*;
+    /// # use std::collections::HashSet;
+    /// let test_map: HashSet<u8> = HashSet::new();
+    /// assert_that(&test_map).is_empty();
+    /// ```
+    fn is_empty(&mut self) {
+        let subject = self.subject;
+
+        if !subject.is_empty() {
+            AssertionFailure::from_spec(self)
+                .with_expected("an empty HashSet".to_string())
+                .with_actual(format!("a HashSet with length <{:?}>", subject.len()))
+                .fail();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::prelude::*;
+
+    use std::collections::HashSet;
+
+    #[test]
+    fn should_not_panic_if_HashSet_length_matches_expected() {
+        let mut test_map = HashSet::new();
+        test_map.insert(1);
+        test_map.insert(2);
+
+        assert_that(&test_map).has_length(2);
+    }
+
+    #[test]
+    #[should_panic(expected = "\n\texpected: HashSet to have length <1>\n\t but was: <2>")]
+    fn should_panic_if_HashSet_length_does_not_match_expected() {
+        let mut test_map = HashSet::new();
+        test_map.insert(1);
+        test_map.insert(2);
+
+        assert_that(&test_map).has_length(1);
+    }
+
+    #[test]
+    fn should_not_panic_if_HashSet_was_expected_to_be_empty_and_is() {
+        let test_map: HashSet<u8> = HashSet::new();
+        assert_that(&test_map).is_empty();
+    }
+
+    #[test]
+    #[should_panic(expected = "\n\texpected: an empty HashSet\
+                   \n\t but was: a HashSet with length <1>")]
+    fn should_panic_if_HashSet_was_expected_to_be_empty_and_is_not() {
+        let mut test_map = HashSet::new();
+        test_map.insert(1);
+
+        assert_that(&test_map).is_empty();
+    }
+
+    #[test]
+    fn contains_should_allow_multiple_borrow_forms() {
+        let mut test_map = HashSet::new();
+        test_map.insert("hello");
+
+        assert_that(&test_map).contains("hello");
+        assert_that(&test_map).contains(&mut "hello");
+        assert_that(&test_map).contains(&"hello");
+    }
+
+    #[test]
+    fn should_not_panic_if_HashSet_contains() {
+        let mut test_map = HashSet::new();
+        test_map.insert("hello");
+
+        assert_that(&test_map).contains(&"hello");
+    }
+
+    #[test]
+    // Unfortunately the order of the keys can change. Doesn't seem to make sense to sort them
+    // just for the sake of checking the panic message.
+    #[should_panic]
+    fn should_not_panic_if_HashSet_does_not_contain() {
+        let mut test_map = HashSet::new();
+        test_map.insert("hi");
+        test_map.insert("hey");
+
+        assert_that(&test_map).contains(&"hello");
+    }
+
+    #[test]
+    fn does_not_contain_should_allow_multiple_borrow_forms() {
+        let mut test_map = HashSet::new();
+        test_map.insert("hello");
+
+        assert_that(&test_map).does_not_contain("hey");
+        assert_that(&test_map).does_not_contain(&mut "hey");
+        assert_that(&test_map).does_not_contain(&"hey");
+    }
+
+    #[test]
+    fn should_not_panic_if_HashSet_does_not_contain_when_expected() {
+        let mut test_map = HashSet::new();
+        test_map.insert("hello");
+
+        assert_that(&test_map).does_not_contain(&"hey");
+    }
+
+    #[test]
+    #[should_panic(expected = "\n\texpected: iterator to not contain <\"hello\">\
+                   \n\t but was: <[\"hello\"]>")]
+    fn should_panic_if_HashSet_does_contain_when_not_expected() {
+        let mut test_map = HashSet::new();
+        test_map.insert("hello");
+
+        assert_that(&test_map).does_not_contain(&"hello");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,7 @@ use colours::{TERM_BOLD, TERM_RED, TERM_RESET};
 
 pub mod boolean;
 pub mod hashmap;
+pub mod hashset;
 pub mod iter;
 pub mod numeric;
 pub mod option;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,6 @@
 pub use super::boolean::BooleanAssertions;
 pub use super::hashmap::{EntryHashMapAssertions, HashMapAssertions, KeyHashMapAssertions};
+pub use super::hashset::HashSetAssertions;
 pub use super::iter::{
     ContainingIntoIterAssertions, ContainingIteratorAssertions, MappingIterAssertions,
 };


### PR DESCRIPTION
This implements Issue #12

- since HashSet implements Iterator contains/does_not_contain etc are accessible via the Iterator traits