### PR TITLE
build: Bump num version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ keywords = ["fluent", "testing", "matchers", "assert", "assertions"]
 default = ["num"]
 
 [dependencies]
-num = { version = "0.1.36", optional = true }
+num = { version = "0.4.0", optional = true }


### PR DESCRIPTION
Bumps `num` version to `0.4.0`. This fixes dependabot security warnings about `rustc-serialize`

<https://github.com/advisories/GHSA-2226-4v3c-cff8>

<img width="1272" alt="Stack overflow in rustc_serialize when parsing deeply nested JSON " src="https://user-images.githubusercontent.com/67512202/193052718-fb8be2ba-f551-4d0b-b8fa-6392d7b66006.png">
